### PR TITLE
suggest shortcuts

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,33 @@
+# Shortcuts within Altadim
+
+As Altadim is heavily influenced by [Omakub](https://omakub.org/),
+this shortcut section is inspired by Omakub's [hotkeys section](https://manual.omakub.org/1/read/29/hotkeys).
+
+## navigating Linux
+
+- open file explorer: `super + f`
+- move to next workstation: `ctrl + super + arrow down`
+- move app to next workstation: `shift + super + arrow down`
+- activate full-screen mode in app: `f11`
+
+## Zellij
+
+- new vertical/horizontal pane: `ctrl + p + r/d`
+- increase/decrease current pane size: `alt +/-`
+- jump to the next pane (also includes tabs): `alt + arrow keys`
+- open a floating pane: `alt + f`
+- create a new tab: `ctrl + t + n`
+
+## Neovim
+
+- open/close the file tree: `space + e`
+  - `h` in file tree: show hidden files (.env files are never shown)
+  - `a` in file tree: create a file or folder (add / to create a folder)
+  - `d` in file tree: delete a file or folder
+  - `ctrl + w + w`: jump from file to file tree and vice versa
+- close the current file: `space + b + d`
+- close all files but the current one: `space + b + o`
+- move to the next file on the left/right: `shift + h/l`
+- open the file finder: `space + space`
+- search all files: `space + s + g`
+- open lazy git: `space + g + g`


### PR DESCRIPTION
- start with linux, zellij, neovim

This pull request adds a new documentation section to `docs/shortcuts.md`, detailing shortcuts for navigating Linux, Zellij, and Neovim within Altadim. The section is inspired by Omakub's hotkeys documentation.

Documentation updates:

* [`docs/shortcuts.md`](diffhunk://#diff-24a989d26fa30832e46fca97c6e37d63f040363600c54db3e2f13a8b9a6dbdc2R1-R33): Added a comprehensive list of shortcuts for Linux navigation, Zellij, and Neovim, providing users with quick reference commands for common tasks. The section is influenced by Omakub's hotkeys documentation.